### PR TITLE
Remove console log statement that shows profile

### DIFF
--- a/server/passport-config.js
+++ b/server/passport-config.js
@@ -19,7 +19,7 @@ const strategy = new Auth0Strategy( {
     // accessToken is the token to call Auth0 API (not needed in the most cases)
     // extraParams.id_token has the JSON Web Token
     // profile has all the information from the user
-    console.log( profile )
+    // console.log( profile )
     Users.findOne( { userName : profile.displayName } )
          .then( user => {
 


### PR DESCRIPTION
I'm commenting out a console.log statement that showed the user's profile info in the server console (in `passport-config.js`.